### PR TITLE
workflows: add radio check workflow

### DIFF
--- a/.github/workflows/radio-health.yml
+++ b/.github/workflows/radio-health.yml
@@ -1,0 +1,24 @@
+name: Check radio health
+
+on:
+  workflow_dispatch: ~
+  schedule:
+    - cron: '37 13 * 1 *'
+  push:
+    paths:
+      - txt/radio-stations.txt
+      - .github/workflows/radio-health.yml
+  pull_request:
+    paths:
+      - txt/radio-stations.txt
+      - .github/workflows/radio-health.yml
+
+jobs:
+  check:
+    name: Check radio health
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run test
+      run: |
+        cat txt/radio-stations.txt | grep -Eo 'https?://(.*)$' | xargs -I {} sh -c 'echo {} && curl -L --head --fail --silent --show-error {} 2>&1 >/dev/null && echo OK'

--- a/.github/workflows/radio-health.yml
+++ b/.github/workflows/radio-health.yml
@@ -21,4 +21,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run test
       run: |
-        cat txt/radio-stations.txt | grep -Eo 'https?://(.*)$' | xargs -I {} sh -c 'echo {} && curl -L --head --fail --silent --show-error {} 2>&1 >/dev/null && echo OK'
+        cat txt/radio-stations.txt \
+        | grep -Eo 'https?://(.*)$' \
+        | xargs -I {} sh -c \
+        'echo {} && $curl {} 2>&1 >/dev/null && echo OK'
+      env:
+        curl: curl -L --head --fail --silent --show-error


### PR DESCRIPTION
Adds a Github Actions workflow that performs a health check of music streams contained in file `txt/radio-stations.txt`. It basically cURLs links extracted from the file and returns non-zero exit code if obtains erroneous response from any of them.

Job should run every first day of the month at 13:37 as well as upon pushing/PRing `txt/radio-stations.txt` file or workflow file itself. It can be also triggered manually at any time.

Demo run:
https://github.com/mard/dotfiles-1/actions/runs/291041914

Successful run:
https://github.com/mard/dotfiles-1/runs/1212785860