### PR TITLE
workflows/radio-health.yml: fix cron expression

### DIFF
--- a/.github/workflows/radio-health.yml
+++ b/.github/workflows/radio-health.yml
@@ -3,7 +3,7 @@ name: Check radio health
 on:
   workflow_dispatch: ~
   schedule:
-    - cron: '37 13 * 1 *'
+    - cron: '37 13 1 * *'
   push:
     paths:
       - txt/radio-stations.txt


### PR DESCRIPTION
Check radio health every first day of the month, not every day in January

Reference: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events